### PR TITLE
Avoid multiple transforms being started at once

### DIFF
--- a/lib/aar-transformer.js
+++ b/lib/aar-transformer.js
@@ -32,6 +32,7 @@ class AarTransformer {
         trace: noop
       };
     }
+    this.started = false;
   }
 
   /**
@@ -41,10 +42,13 @@ class AarTransformer {
    * @param {Function} callback Callback function
    */
   transform(options, callback) {
-    this.reset();
+    if (this.started === true) {
+      throw new Error('You can only start a transform once per Transformer instance. Please create a new one if you want to run anoter transform.');
+    }
 
     this.logger.debug('AAR transform options: %s', JSON.stringify(options, null, 2));
 
+    this.started = true;
     async.series([
       async.apply(this.validateAndApplyOptions.bind(this), options),
       (next) => {
@@ -67,18 +71,6 @@ class AarTransformer {
     ], (err) => {
       callback(err, this.result);
     });
-  }
-
-  /**
-   * Resets this transformer for a new transform task.
-   */
-  reset() {
-    this.result = new TransformationResult();
-    this.aarPathAndFilename = null;
-    this.outputPath = null;
-    this.assetsDestinationPath = null;
-    this.libraryDestinationPath = null;
-    this.sharedLibraryDestinationPath = null;
   }
 
   /**


### PR DESCRIPTION
Enforce the creation of a new AarTransformer instance for each transform task. The old approach of resetting the instance for each transform was causing issues when they were executed in parallel.